### PR TITLE
chore(renovate): use shared org renovate-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "github>NLueg/renovate-config"
   ]
 }


### PR DESCRIPTION
Extends the org's shared `renovate-config` repo instead of Renovate's default `config:recommended` preset, so this repo picks up the shared package rules (grouping, minimum release age, etc.).